### PR TITLE
Fix has_blob api behaviour

### DIFF
--- a/src/api/has.ts
+++ b/src/api/has.ts
@@ -9,5 +9,4 @@ router.head("/:hash", async (ctx, next) => {
   const has = blobDB.hasBlob(hash);
   if (has) ctx.status = 200;
   else ctx.status = 404;
-  ctx.body = null;
 });


### PR DESCRIPTION
Removes the code line that set the body to null. Although the intention here probably was to not have a body, the Koa framework actually seem to alter the status code if the body is set to anything (including null). This change ensures that the status code is set to 200 if blob exists and 404 if not.

Documentation for the behaviour in Koa can be found [here](https://github.com/koajs/koa/blob/master/docs/api/response.md#responsebody-1).

Another way this could be handled would be to set the body to null first and then specifically set the status code but I don't see any reason to keep the code line when it's not needed.

Fixes #4.