### PR TITLE
feat: add NIP-05 whitelist for upload, mirror, and delete endpoints

### DIFF
--- a/.changeset/nip05-whitelist.md
+++ b/.changeset/nip05-whitelist.md
@@ -1,0 +1,5 @@
+---
+"blossom-server-ts": minor
+---
+
+Add NIP-05 whitelist: restrict uploads, mirrors, and deletes to pubkeys registered on a NIP-05 domain

--- a/config.example.yml
+++ b/config.example.yml
@@ -1,5 +1,5 @@
 # Blossom Server Configuration
-# 
+#
 # Environment Variable Support:
 # You can use environment variables in this config file using the syntax: "${VAR_NAME}"
 # For example: password: "${BLOSSOM_ADMIN_PASSWORD}"
@@ -57,7 +57,7 @@ storage:
   #   region: us-east-1
   #   If this is set the server will redirect clients when loading blobs
   #   publicURL: https://s3.region.example.com/
-  #   
+  #
   #   You can also use environment variables for sensitive values:
   #   accessKey: "${S3_ACCESS_KEY}"
   #   secretKey: "${S3_SECRET_KEY}"
@@ -140,3 +140,19 @@ list:
 tor:
   enabled: false
   proxy: ""
+# NIP-05 whitelist: restrict uploads, mirrors, and deletes to users registered on a NIP-05 domain.
+# When enabled, a pubkey must appear in either the NIP-05 domain fetch or the hard-coded list.
+# The NIP-05 list is re-fetched every `refreshInterval` seconds. On fetch failure, the last
+# known-good cache is preserved; hard-coded pubkeys are always trusted regardless.
+# whitelist:
+#   # Enable the whitelist (default: false)
+#   enabled: false
+#   # NIP-05 domain to fetch pubkeys from (fetches https://<domain>/.well-known/nostr.json)
+#   nip05Domain: "example.com"
+#   # Optional hard-coded hex pubkeys always allowed, regardless of domain fetch result
+#   pubkeys:
+#     - "hex_pubkey_here"
+#   # Custom 401 error message for non-whitelisted users
+#   errorMessage: "You are not authorized to upload."
+#   # How often to re-fetch the NIP-05 domain list, in seconds (default: 3600)
+#   refreshInterval: 3600

--- a/src/api/delete.ts
+++ b/src/api/delete.ts
@@ -5,6 +5,7 @@ import { forgetBlobAccessed } from "../db/methods.js";
 import { blobDB } from "../db/db.js";
 import { config } from "../config.js";
 import storage from "../storage/index.js";
+import { isWhitelisted } from "../whitelist.js";
 
 router.delete<CommonState>("/:hash", async (ctx, next) => {
   const match = ctx.path.match(/([0-9a-f]{64})(\.[a-z]+)?/);
@@ -15,6 +16,14 @@ router.delete<CommonState>("/:hash", async (ctx, next) => {
   if (ctx.state.authType !== "delete") throw new HttpErrors.Unauthorized("Incorrect Auth type");
   if (!ctx.state.auth.tags.some((t) => t[0] === "x" && t[1] === sha256))
     throw new HttpErrors.Unauthorized("Auth missing hash");
+
+  // check whitelist
+  if (config.whitelist.enabled) {
+    const pubkey = ctx.state.auth.pubkey;
+    if (!(await isWhitelisted(pubkey))) {
+      throw new HttpErrors.Unauthorized(config.whitelist.errorMessage ?? "You are not authorized to upload.");
+    }
+  }
 
   // skip if blob dose not exist
   if (!blobDB.hasBlob(sha256)) throw new HttpErrors.NotFound("Blob does not exist");

--- a/src/api/mirror.ts
+++ b/src/api/mirror.ts
@@ -14,6 +14,7 @@ import { config } from "../config.js";
 import { updateBlobAccess } from "../db/methods.js";
 import { UploadDetails, readUpload, removeUpload, saveFromResponse } from "../storage/upload.js";
 import { blobDB } from "../db/db.js";
+import { isWhitelisted } from "../whitelist.js";
 
 function makeRequestWithAbort(url: URL) {
   return new Promise<{ response: IncomingMessage; controller: AbortController }>((res, rej) => {
@@ -41,6 +42,14 @@ router.put<CommonState>("/mirror", async (ctx) => {
   if (config.upload.requireAuth) {
     if (!ctx.state.auth) throw new HttpErrors.Unauthorized("Missing Auth event");
     if (ctx.state.authType !== "upload") throw new HttpErrors.Unauthorized("Auth event should be 'upload'");
+  }
+
+  // check whitelist
+  if (config.whitelist.enabled) {
+    const pubkey = ctx.state.auth?.pubkey;
+    if (!pubkey || !(await isWhitelisted(pubkey))) {
+      throw new HttpErrors.Unauthorized(config.whitelist.errorMessage ?? "You are not authorized to upload.");
+    }
   }
 
   if (!ctx.request.body?.url) throw new HttpErrors.BadRequest("Missing url");

--- a/src/api/upload.ts
+++ b/src/api/upload.ts
@@ -7,6 +7,7 @@ import { getFileRule } from "../rules/index.js";
 import { config, Rule } from "../config.js";
 import { removeUpload, saveFromUploadRequest } from "../storage/upload.js";
 import { blobDB } from "../db/db.js";
+import { isWhitelisted } from "../whitelist.js";
 
 export type UploadState = CommonState & {
   contentType: string;
@@ -30,6 +31,14 @@ export function checkUpload(
         if (typeof sha256 !== "string") throw new HttpErrors.BadRequest("Missing X-SHA-256 header");
         if (!ctx.state.auth.tags.some((t) => t[0] === "x" && t[1] === sha256))
           throw new HttpErrors.Unauthorized("Auth missing sha256");
+      }
+
+      // check whitelist
+      if (config.whitelist.enabled) {
+        const pubkey = ctx.state.auth?.pubkey;
+        if (!pubkey || !(await isWhitelisted(pubkey))) {
+          throw new HttpErrors.Unauthorized(config.whitelist.errorMessage ?? "You are not authorized to upload.");
+        }
       }
 
       // check rules

--- a/src/config.ts
+++ b/src/config.ts
@@ -64,6 +64,18 @@ export type Config = {
     enabled: boolean;
     proxy: string;
   };
+  whitelist: {
+    /** Enable the NIP-05 whitelist. When true, only whitelisted pubkeys may upload/mirror/delete. */
+    enabled: boolean;
+    /** NIP-05 domain to fetch pubkeys from (fetches /.well-known/nostr.json). */
+    nip05Domain?: string;
+    /** Hard-coded hex pubkeys that are always allowed, regardless of domain fetch result. */
+    pubkeys?: string[];
+    /** Error message returned to non-whitelisted users. */
+    errorMessage?: string;
+    /** How often to re-fetch the NIP-05 domain list, in seconds. Default: 3600. */
+    refreshInterval?: number;
+  };
 };
 
 /**
@@ -72,7 +84,7 @@ export type Config = {
  * If the environment variable is not set, the original string is kept.
  */
 function interpolateEnvVars(obj: any): any {
-  if (typeof obj === 'string') {
+  if (typeof obj === "string") {
     // Match ${VAR_NAME} pattern
     return obj.replace(/\$\{([^}]+)\}/g, (match, varName) => {
       const envValue = process.env[varName];
@@ -80,7 +92,7 @@ function interpolateEnvVars(obj: any): any {
     });
   } else if (Array.isArray(obj)) {
     return obj.map(interpolateEnvVars);
-  } else if (obj !== null && typeof obj === 'object') {
+  } else if (obj !== null && typeof obj === "object") {
     const result: any = {};
     for (const [key, value] of Object.entries(obj)) {
       result[key] = interpolateEnvVars(value);
@@ -117,6 +129,13 @@ const defaultConfig: Config = {
   media: { enabled: false, requireAuth: true, requirePubkeyInRule: false },
   list: { requireAuth: false, allowListOthers: false },
   tor: { enabled: false, proxy: "" },
+  whitelist: {
+    enabled: false,
+    nip05Domain: undefined,
+    pubkeys: undefined,
+    errorMessage: "You are not authorized to upload.",
+    refreshInterval: 3600,
+  },
 };
 
 const searchPlaces = ["config.yaml", "config.yml", "config.json"];

--- a/src/whitelist.ts
+++ b/src/whitelist.ts
@@ -1,0 +1,58 @@
+import { config } from "./config.js";
+import logger from "./logger.js";
+
+const log = logger.extend("whitelist");
+
+// Cached set of allowed pubkeys (hex). Starts empty.
+// When enabled + domain configured, an empty cache means everyone is denied (fail closed).
+let whitelistCache: Set<string> = new Set();
+let lastFetchTime = 0;
+
+async function refreshWhitelist(): Promise<void> {
+  if (!config.whitelist.nip05Domain) return;
+
+  try {
+    const data: unknown = await fetch(`https://${config.whitelist.nip05Domain}/.well-known/nostr.json`).then((res) =>
+      res.json(),
+    );
+
+    if (data && typeof data === "object" && "names" in data && data.names && typeof data.names === "object") {
+      // NIP-05: the values of the "names" map are hex pubkeys
+      const fetched = new Set<string>(Object.values(data.names as Record<string, string>));
+
+      // Union with hard-coded pubkeys from config
+      whitelistCache = new Set<string>([...(config.whitelist.pubkeys ?? []), ...fetched]);
+      lastFetchTime = Date.now();
+      log("Refreshed whitelist from %s: %d pubkeys", config.whitelist.nip05Domain, whitelistCache.size);
+    }
+  } catch (error) {
+    log("Failed to fetch NIP-05 whitelist from %s: %o", config.whitelist.nip05Domain, error);
+    // Fail closed: do not update cache on error.
+    // Hard-coded pubkeys (config.whitelist.pubkeys) are still checked directly in isWhitelisted.
+  }
+}
+
+/**
+ * Returns true if the given hex pubkey is allowed by the whitelist.
+ *
+ * When whitelist is disabled, always returns true.
+ * When enabled, the cache is refreshed if stale, then the pubkey is checked
+ * against the union of the NIP-05 domain fetch and the hard-coded pubkeys list.
+ * Hard-coded pubkeys are always checked even if the domain fetch failed.
+ */
+export async function isWhitelisted(pubkey: string): Promise<boolean> {
+  if (!config.whitelist.enabled) return true;
+
+  const now = Date.now();
+  const refreshInterval = (config.whitelist.refreshInterval ?? 3600) * 1000;
+
+  // Refresh if cache is stale or has never been populated
+  if (now - lastFetchTime >= refreshInterval) {
+    await refreshWhitelist();
+  }
+
+  // Hard-coded pubkeys are always trusted, even if the domain fetch failed
+  if (config.whitelist.pubkeys?.includes(pubkey)) return true;
+
+  return whitelistCache.has(pubkey);
+}


### PR DESCRIPTION
Adds a configurable whitelist that restricts write operations to pubkeys registered on a NIP-05 domain. The whitelist is fetched from the domain's /.well-known/nostr.json, cached in memory, and refreshed on a configurable interval. Hard-coded pubkeys can be added alongside the domain fetch (OR logic). Fails closed on fetch error. Disabled by default.

Alternative to https://github.com/hzrd149/blossom-server/pull/22