### PR TITLE
Drain the request body on dedup hits instead of cancelling

### DIFF
--- a/src/routes/upload.ts
+++ b/src/routes/upload.ts
@@ -38,6 +38,7 @@ import { getPool, WorkerJobError } from "../workers/pool.ts";
 import type { Config } from "../config/schema.ts";
 import { mimeToExt } from "../utils/mime.ts";
 import { type Nip94Tag, nip94Tags, optionalNip94Tags } from "../utils/nip94.ts";
+import { drainBody } from "../utils/streams.ts";
 import { getBaseUrl, getBlobUrl } from "../utils/url.ts";
 import { getFileRule } from "../prune/rules.ts";
 import { extractDimensions } from "../optimize/dimensions.ts";
@@ -267,9 +268,12 @@ export function buildUploadRouter(
 
     // --- 6. Dedup: if blob already exists, skip the whole write ---
     if (xSha256 && (await hasBlob(db, xSha256))) {
-      await ctx.req.raw.body?.cancel();
       const existing = await getBlob(db, xSha256);
       if (existing) {
+        // Drain, don't cancel — this returns 200 and the client may still be
+        // sending. See drainBody(). Only reached when the client skipped the
+        // BUD-06 preflight that exists to avoid this transfer.
+        await drainBody(ctx.req.raw.body);
         debug(
           debugPrefix,
           `dedup hit — returning existing blob ${xSha256.slice(0, 8)}`,

--- a/src/utils/streams.ts
+++ b/src/utils/streams.ts
@@ -3,6 +3,28 @@
  */
 
 /**
+ * Reads `body` to completion and discards it.
+ *
+ * Cancelling a request body the client is still streaming resets the request
+ * stream. Firefox surfaces that to the caller as NS_ERROR_NET_PARTIAL_TRANSFER
+ * even when the response is a success, so any path that returns 2xx while the
+ * upload is still in flight must drain instead of cancel. Rejection paths
+ * should keep cancelling — accepting bytes only to throw them away is worse.
+ *
+ * Draining costs the inbound bandwidth. Clients that want to avoid the transfer
+ * altogether should preflight with HEAD /upload (BUD-06).
+ *
+ * Never throws: a client vanishing mid-drain is not worth failing a response
+ * that has already been decided.
+ */
+export async function drainBody(
+  body: ReadableStream<Uint8Array> | null,
+): Promise<void> {
+  if (!body) return;
+  await body.pipeTo(new WritableStream()).catch(() => {});
+}
+
+/**
  * Returns a TransformStream that passes bytes through until exactly `limit`
  * bytes have been forwarded, then closes the readable side.
  *

--- a/tests/e2e/upload.test.ts
+++ b/tests/e2e/upload.test.ts
@@ -616,6 +616,62 @@ Deno.test({
 });
 
 Deno.test({
+  name: "PUT /upload: dedup hit drains the request body rather than cancelling",
+  async fn() {
+    const body = new TextEncoder().encode("drain-on-dedup payload");
+    const hash = await sha256Hex(body);
+
+    // Seed the blob so the next upload takes the dedup path.
+    const seed = await fetchNoAuth("/upload", {
+      method: "PUT",
+      headers: {
+        "Content-Length": String(body.byteLength),
+        "Content-Type": "application/octet-stream",
+        "X-SHA-256": hash,
+      },
+      body: body.slice(),
+    });
+    assertEquals(seed.status, 201);
+
+    // Re-upload with a streaming body that records whether it was cancelled.
+    // Cancelling a body the client is still sending resets the request stream,
+    // which Firefox reports as NS_ERROR_NET_PARTIAL_TRANSFER even though this
+    // path returns 200 — so the dedup response must consume the stream.
+    let cancelled = false;
+    let offset = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (offset >= body.byteLength) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(body.slice(offset, offset + 8));
+        offset += 8;
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+
+    const res = await fetchNoAuth("/upload", {
+      method: "PUT",
+      headers: {
+        "Content-Length": String(body.byteLength),
+        "Content-Type": "application/octet-stream",
+        "X-SHA-256": hash,
+      },
+      body: stream,
+    });
+
+    assertEquals(res.status, 200);
+    await res.json();
+    assertEquals(cancelled, false);
+    assertEquals(offset >= body.byteLength, true);
+  },
+  ...testOpts,
+});
+
+Deno.test({
   name: "GET /list/:pubkey returns full valid blob URLs using request scheme",
   async fn() {
     const listDb = await initDb({ path: join(tmpDir, "list-url-test.db") });


### PR DESCRIPTION
PUT /upload returns a BlobDescriptor with 200 when X-SHA-256 matches a blob that is already stored, without reading the request body. Cancelling a body the client is still streaming resets the request stream. Firefox surfaces that as NS_ERROR_NET_PARTIAL_TRANSFER, or as a CORS failure with a null status when the reset beats the response, even though the upload logically succeeded and the blob is on the server.

Small uploads fit in socket and proxy buffers and finish writing before the early return lands, so this only shows up once the body is large enough to still be in flight — which reads to users as an arbitrary size limit. It also only triggers on re-upload, since dedup is content addressed, so the first upload of a file always works and every retry fails.

Drain the body on this path instead. It costs the inbound bandwidth that dedup was meant to save; clients that want to skip the transfer entirely should preflight with HEAD /upload (BUD-06), which already reports dedup hits. Rejection paths keep cancelling, since accepting bytes only to discard them is worse than a reset the client already knows about.

Also fixes a latent bug: the body was cancelled before getBlob() was checked for null, so a hasBlob/getBlob race would fall through to the worker dispatch with an already-cancelled body.