### PR TITLE
fix(blobs): clamp ranges that end past EOF instead of returning 416

### DIFF
--- a/src/routes/blobs.ts
+++ b/src/routes/blobs.ts
@@ -131,7 +131,20 @@ export function buildBlobsRouter(
   return app;
 }
 
-/** Parse a Range: bytes=start-end header. Returns null for unsatisfiable ranges. */
+/**
+ * Parse a `Range: bytes=start-end` header. Returns null for unsatisfiable ranges.
+ *
+ * Per RFC 9110 §14.1.2, a last-byte-pos at or beyond the end of the
+ * representation is clamped to the last byte rather than rejected, and a
+ * suffix-length longer than the representation selects the whole thing. Only a
+ * first-byte-pos at or past the end makes a range unsatisfiable.
+ *
+ * Clamping is what lets range-slicing caches work. nginx's slice module, for
+ * one, asks for fixed-size aligned slices (`bytes=1048576-2097151`), so the
+ * final slice of any file that isn't an exact multiple of the slice size always
+ * runs past EOF. Answering 416 there makes the cache abort mid-file and hand
+ * the client a truncated body.
+ */
 export function parseRange(
   header: string,
   totalSize: number,
@@ -145,15 +158,20 @@ export function parseRange(
   if (isNaN(start) && isNaN(end)) return null;
 
   if (isNaN(start)) {
-    // Suffix range: bytes=-500 → last 500 bytes
-    start = totalSize - end;
+    // Suffix range: bytes=-500 → last 500 bytes. A suffix-length of 0 selects
+    // nothing and is unsatisfiable; one longer than the file selects all of it.
+    if (end === 0) return null;
+    start = Math.max(0, totalSize - end);
     end = totalSize - 1;
   } else if (isNaN(end)) {
     // Open range: bytes=500- → from byte 500 to end
     end = totalSize - 1;
+  } else if (end >= totalSize) {
+    // Explicit range running past EOF → clamp to the last byte
+    end = totalSize - 1;
   }
 
-  if (start < 0 || end >= totalSize || start > end) return null;
+  if (start >= totalSize || start > end) return null;
   return { start, end };
 }
 

--- a/tests/e2e/blobs.test.ts
+++ b/tests/e2e/blobs.test.ts
@@ -301,6 +301,50 @@ Deno.test({
   ...testOpts,
 });
 
+Deno.test({
+  name: "GET blob: range ending past EOF is clamped to the last byte",
+  async fn() {
+    const res = await app.fetch(
+      new Request(`http://localhost${blobUrl}`, {
+        headers: { Range: `bytes=0-${BLOB_SIZE}` },
+      }),
+    );
+    assertEquals(res.status, 206);
+    assertEquals(
+      res.headers.get("Content-Range"),
+      `bytes 0-${BLOB_SIZE - 1}/${BLOB_SIZE}`,
+    );
+    assertEquals(res.headers.get("Content-Length"), String(BLOB_SIZE));
+
+    const body = new Uint8Array(await res.arrayBuffer());
+    assertEquals(body, BLOB_DATA);
+  },
+  ...testOpts,
+});
+
+Deno.test({
+  name: "GET blob: aligned slice past EOF returns the remainder, not 416",
+  async fn() {
+    // The shape nginx's slice module produces for a final slice: the start is
+    // inside the blob, the end runs past it.
+    const res = await app.fetch(
+      new Request(`http://localhost${blobUrl}`, {
+        headers: { Range: `bytes=16-${BLOB_SIZE + 500}` },
+      }),
+    );
+    assertEquals(res.status, 206);
+    assertEquals(
+      res.headers.get("Content-Range"),
+      `bytes 16-${BLOB_SIZE - 1}/${BLOB_SIZE}`,
+    );
+    assertEquals(res.headers.get("Content-Length"), String(BLOB_SIZE - 16));
+
+    const body = new Uint8Array(await res.arrayBuffer());
+    assertEquals(body, BLOB_DATA.subarray(16));
+  },
+  ...testOpts,
+});
+
 // ---------------------------------------------------------------------------
 // Range — 416 cases
 // ---------------------------------------------------------------------------
@@ -315,20 +359,6 @@ Deno.test({
     );
     assertEquals(res.status, 416);
     assertEquals(res.headers.get("Content-Range"), `bytes */${BLOB_SIZE}`);
-    await res.body?.cancel();
-  },
-  ...testOpts,
-});
-
-Deno.test({
-  name: "GET blob: end >= size returns 416",
-  async fn() {
-    const res = await app.fetch(
-      new Request(`http://localhost${blobUrl}`, {
-        headers: { Range: `bytes=0-${BLOB_SIZE}` },
-      }),
-    );
-    assertEquals(res.status, 416);
     await res.body?.cancel();
   },
   ...testOpts,

--- a/tests/unit/range.test.ts
+++ b/tests/unit/range.test.ts
@@ -45,6 +45,31 @@ Deno.test("parseRange: suffix range equal to file size (bytes=-1000)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// parseRange — RFC 9110 §14.1.2 clamping
+// ---------------------------------------------------------------------------
+
+Deno.test("parseRange: end past EOF is clamped to the last byte", () => {
+  assertEquals(parseRange("bytes=0-1000", 1000), { start: 0, end: 999 });
+});
+
+Deno.test("parseRange: end far past EOF is clamped to the last byte", () => {
+  assertEquals(parseRange("bytes=500-999999", 1000), { start: 500, end: 999 });
+});
+
+Deno.test("parseRange: nginx-style aligned slice past EOF is clamped", () => {
+  // `slice 1m` asks for bytes=1048576-2097151 on a 1111411-byte file: the
+  // start is inside the file, so the range is satisfiable and clamps to EOF.
+  assertEquals(parseRange("bytes=1048576-2097151", 1111411), {
+    start: 1048576,
+    end: 1111410,
+  });
+});
+
+Deno.test("parseRange: suffix longer than the file selects the whole file", () => {
+  assertEquals(parseRange("bytes=-5000", 1000), { start: 0, end: 999 });
+});
+
+// ---------------------------------------------------------------------------
 // parseRange — unsatisfiable / invalid inputs → null
 // ---------------------------------------------------------------------------
 
@@ -52,12 +77,20 @@ Deno.test("parseRange: start > end is unsatisfiable", () => {
   assertEquals(parseRange("bytes=100-99", 1000), null);
 });
 
-Deno.test("parseRange: end >= totalSize is unsatisfiable", () => {
-  assertEquals(parseRange("bytes=0-1000", 1000), null);
-});
-
 Deno.test("parseRange: start equals totalSize is unsatisfiable", () => {
   assertEquals(parseRange("bytes=1000-1000", 1000), null);
+});
+
+Deno.test("parseRange: start past totalSize is unsatisfiable", () => {
+  assertEquals(parseRange("bytes=1500-2000", 1000), null);
+});
+
+Deno.test("parseRange: open-end range starting past EOF is unsatisfiable", () => {
+  assertEquals(parseRange("bytes=1000-", 1000), null);
+});
+
+Deno.test("parseRange: suffix range on a 0-byte file is unsatisfiable", () => {
+  assertEquals(parseRange("bytes=-5", 0), null);
 });
 
 Deno.test("parseRange: suffix of 0 (bytes=-0) is unsatisfiable", () => {


### PR DESCRIPTION
`parseRange()` treats a `last-byte-pos` at or beyond the end of the blob as unsatisfiable:

```ts
if (start < 0 || end >= totalSize || start > end) return null;
```

RFC 9110 §14.1.2 says the opposite — an end position past the end of the representation is clamped, not rejected:

> If the last-byte-pos value is absent, or if the value is greater than or equal to the current length of the representation data, the byte range is interpreted as the remainder of the representation.

A range is unsatisfiable only when `first-byte-pos` is at or past the end. The same section says a `suffix-length` longer than the representation selects the whole thing, which was also being rejected (via `start < 0`).

## Why it matters

This breaks range-slicing caches in front of a Blossom server. nginx's `slice` module asks for fixed-size aligned slices:

```
Range: bytes=0-1048575
Range: bytes=1048576-2097151
...
```

The last slice of any blob that isn't an exact multiple of the slice size runs past EOF — as does the *first* slice of any blob smaller than one slice. With a 1 MiB slice size, only blobs that are an exact multiple of 1 MiB survive; everything else gets a 416 partway through.

nginx then gives up and hands the client a truncated body under the full `Content-Length`. Browsers render the partial image and discard it; over HTTP/3 Chrome reports `ERR_QUIC_PROTOCOL_ERROR`.

Observed on a 1,111,411-byte PNG served through a Pleroma media proxy with `slice 1m`:

```
$ curl -H 'Range: bytes=1048576-2097151' https://blossom.example/<sha256>.png
HTTP/2 416
content-range: bytes */1111411
```

The client received 1,048,576 of 1,111,411 bytes — exactly one slice.

## The fix

`end >= totalSize` clamps to `totalSize - 1`; a suffix longer than the blob clamps to `start = 0`; a suffix-length of `0` stays unsatisfiable. The satisfiability check becomes `start >= totalSize || start > end`. 416 responses keep their `Content-Range: bytes */size`.

After:

```
HTTP/2 206
content-range: bytes 1048576-1111410/1111411
```

## Tests

Added unit cases for past-EOF clamping (explicit, far-past, nginx-aligned) and the over-long suffix, plus e2e cases asserting 206 with the clamped `Content-Range` and correct body bytes.

Two existing tests asserted the old behaviour and have been updated:

- `parseRange: end >= totalSize is unsatisfiable` — replaced by `parseRange: end past EOF is clamped to the last byte`
- `GET blob: end >= size returns 416` — replaced by `GET blob: range ending past EOF is clamped to the last byte`

Genuinely unsatisfiable ranges still return 416, and are still covered: `start` at or past EOF, `start > end`, `bytes=-0`, malformed headers, multi-range, and open-end ranges on a 0-byte blob.

Full suite passes (152 tests). Note that `deno task test` currently fails type-checking on an unrelated pre-existing error in `src/routes/media.ts:51` (`ReadableStream` lacking `[Symbol.asyncIterator]`), present on `master` too — I ran with `--no-check` to get a green run and left it alone.

## Verification

Deployed to a production Blossom server and checked against a real 1,111,411-byte blob. The two slices now reassemble to a blob whose SHA-256 equals its content address, and the end-to-end fetch through the nginx slice proxy returns all 1,111,411 bytes.

| Range | Before | After |
| --- | --- | --- |
| `bytes=0-1048575` | 206 `bytes 0-1048575/1111411` | unchanged |
| `bytes=1048576-2097151` | **416** | 206 `bytes 1048576-1111410/1111411` |
| `bytes=0-99999999` | **416** | 206 `bytes 0-1111410/1111411` |
| `bytes=-99999999` | **416** | 206 `bytes 0-1111410/1111411` |
| `bytes=1111411-1111500` | 416 | 416 (start past EOF) |
| `bytes=100-99` | 416 | 416 |
| `bytes=-0` | 416 | 416 |

## Out of scope

Multi-range requests (`bytes=0-50,100-150`) still return 416 rather than a `multipart/byteranges` response or a 200 fallback. That's a separate change; this PR only touches the single-range path.
